### PR TITLE
docs: rewrite academy page titles and meta descriptions for SEO

### DIFF
--- a/developer-tools/console-debugging.mdx
+++ b/developer-tools/console-debugging.mdx
@@ -1,7 +1,9 @@
+---
 title: 'Console Debugging'
-description: 'Master the art of debugging with browser console tools and streamline error resolution with Softgen.ai'
+description: 'Use the browser console to debug your Softgen app. Read errors, trace issues, and resolve them quickly.'
 keywords: ['Console Debugging', 'Browser Tools', 'Error Resolution']
 author: 'Softgen.ai Developer Team'
+---
 
 ## How to Debug in the Browser Console
 

--- a/developer-tools/frontend-vs-fullstack.mdx
+++ b/developer-tools/frontend-vs-fullstack.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Frontend vs Full Stack Projects'
-description: 'Understanding the differences between Frontend and Full Stack development modes in Softgen'
+description: 'Understand the difference between Frontend and Full Stack modes in Softgen and choose the right setup for your app.'
 ---
 
 Softgen offers two powerful development modes to match your project needs: Frontend and Full Stack. Each mode is optimized for different use cases and comes with its own set of features and capabilities.

--- a/developer-tools/network-debugging.mdx
+++ b/developer-tools/network-debugging.mdx
@@ -1,7 +1,9 @@
+---
 title: 'Network Debugging'
-description: 'Enhance your debugging skills by mastering network request analysis and troubleshooting with Softgen.ai'
+description: 'Debug network requests in your Softgen app. Analyze API calls, inspect responses, and fix issues fast.'
 keywords: ['Network Debugging', 'Request Analysis', 'Troubleshooting']
 author: 'Softgen.ai Developer Team'
+---
 
 ## How to Debug Network Requests
 

--- a/fullstack/firebase/database-operations.mdx
+++ b/fullstack/firebase/database-operations.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Database Operations'
-description: 'Learn how to perform database operations with Firebase Firestore in your Full Stack project'
+title: 'Database Operations with Firestore'
+description: 'Read, write, and query data in your Softgen app using Firebase Firestore. Learn core database operations with AI.'
 ---
 
 After setting up [Firebase Onboarding](/fullstack/firebase-onboarding) and [User Authentication](/fullstack/user-authentication), you can implement database operations in your application. This guide shows how to use Softgen.ai to manage your data with Firebase Firestore.

--- a/fullstack/firebase/file-storage.mdx
+++ b/fullstack/firebase/file-storage.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'File Storage'
-description: 'Implement file storage and management using Firebase Storage in your Full Stack project'
+title: 'File Storage with Firebase'
+description: 'Add file uploads and storage to your Softgen app using Firebase Storage. Handle images, documents, and media.'
 ---
 
 After setting up [Firebase Onboarding](/fullstack/firebase-onboarding), you can implement file storage in your application. This guide shows how to use Softgen.ai to manage file uploads and storage with Firebase Storage.

--- a/fullstack/firebase/firebase-onboarding.mdx
+++ b/fullstack/firebase/firebase-onboarding.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Firebase Onboarding'
-description: 'Step-by-step guide to setting up Firebase in your Full Stack project'
+title: 'Firebase Setup for Full Stack Apps'
+description: 'Set up Firebase in your Softgen full-stack app. A step-by-step onboarding guide for auth, database, and storage.'
 ---
 
 ## Note: This guide is deprecated. [Supabase](/fullstack/supabase/supabase-onboarding) is now Softgen's default database option, and generally works much more smoothly. 

--- a/fullstack/firebase/realtime-applications.mdx
+++ b/fullstack/firebase/realtime-applications.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Real-time Applications'
-description: 'Build real-time features using Firebase Realtime Database in your Full Stack project'
+title: 'Real-Time Apps with Firebase'
+description: 'Build real-time features in your Softgen app with the Firebase Realtime Database, from live updates to chat.'
 ---
 
 After setting up [Firebase Onboarding](/fullstack/firebase-onboarding), [User Authentication](/fullstack/user-authentication), and [Database Operations](/fullstack/database-operations), you can implement real-time features in your application. This guide shows how to use Softgen.ai to create real-time applications with Firebase.

--- a/fullstack/firebase/user-authentication.mdx
+++ b/fullstack/firebase/user-authentication.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'User Authentication'
-description: 'Implement secure user authentication in your Full Stack project with Firebase Auth'
+title: 'User Authentication with Firebase'
+description: 'Add secure user authentication to your Softgen app with Firebase Auth. Sign-up, login, and session handling made simple.'
 ---
 
 After completing the [Firebase Onboarding](/fullstack/firebase-onboarding) process, you can implement user authentication in your application. This guide shows how to use Softgen.ai to quickly set up secure user authentication.

--- a/fullstack/supabase/supabase-onboarding.mdx
+++ b/fullstack/supabase/supabase-onboarding.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Supabase Integration'
-description: 'One-click Supabase setup managed by Softgen Platform'
+title: 'Supabase Integration for Full Stack Apps'
+description: 'Add a Supabase backend to your Softgen app with one-click setup. Database, auth, and storage managed for you.'
 ---
 
 # Connect Your Project to Supabase

--- a/guides/deployment.mdx
+++ b/guides/deployment.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Deployment with Vercel'
-description: 'Comprehensive guide to deploying Softgen projects on Vercel'
+title: 'Deploy Your App with Vercel'
+description: 'Deploy your Softgen web app to production on Vercel. A complete guide to publishing your project and going live.'
 ---
 
 import { Callout } from 'nextra-theme-docs'

--- a/guides/domain-connection.mdx
+++ b/guides/domain-connection.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Domain Connection'
-description: 'Connect your custom domain to your Softgen project'
+title: 'Connect a Custom Domain'
+description: 'Connect your custom domain to your Softgen web app. A step-by-step setup to launch your project on your own URL.'
 ---
 
 # Connecting Your Domain

--- a/guides/getting-started.mdx
+++ b/guides/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Getting Started'
-description: 'Learn how to create and improve your first project with Softgen'
+title: 'Getting Started with Softgen'
+description: 'Create, preview, and improve your first AI-built web app. A practical getting started guide for the Softgen app builder.'
 ---
 
 This guide will help you get started with Softgen's AI-powered development platform.

--- a/guides/import-from-lovable.mdx
+++ b/guides/import-from-lovable.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Import from Lovable'
-description: 'Move your Lovable project into Softgen in a few steps by exporting it to GitHub first'
+title: 'Import from Lovable to Softgen'
+description: 'Move your Lovable project into Softgen in a few steps by exporting it to GitHub first, then keep building with AI.'
 ---
 
 ## Overview

--- a/guides/prompting/advanced-prompting.mdx
+++ b/guides/prompting/advanced-prompting.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Advanced Prompting'
-description: 'Unlock advanced AI collaboration techniques for transforming your software development workflow'
+title: 'Advanced Prompting Techniques for AI App Building'
+description: 'Master advanced prompting to guide Softgen through complex features, refactors, and full-stack logic with precision.'
 ---
 
 ## Introduction: The Power of Precise Communication

--- a/guides/prompting/basic-prompting.mdx
+++ b/guides/prompting/basic-prompting.mdx
@@ -1,10 +1,9 @@
 ---
-title: 'Basic Prompting'
-description: 'Unlock the power of effective communication with AI through strategic prompting techniques'
+title: 'Basic Prompting: Get Better Results from AI'
+description: 'Learn prompting techniques that get accurate results from the Softgen AI builder. Write clear prompts and build faster.'
 keywords: ['AI Prompting', 'Communication Strategies', 'AI Collaboration']
 author: 'AI Communication Experts'
 ---
-
 
 ## Understanding Prompting: More Than Just Instructions
 

--- a/guides/prompting/context-window-management.mdx
+++ b/guides/prompting/context-window-management.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Context-Window & Thread Management'
-description: 'Practical playbook for staying in the token sweet-spot when collaborating with Softgen AI'
+title: 'Context Window and Thread Management'
+description: 'Keep prompts in the token sweet spot. Manage context windows and threads to get faster, more accurate AI builds in Softgen.'
 ---
 
 ## Why Effective Context Management Matters

--- a/guides/step-by-step.mdx
+++ b/guides/step-by-step.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Step-by-Step Tutorial'
-description: 'Detailed walkthrough of building with Softgen'
+title: 'Step-by-Step Tutorial: Build a Web App with AI'
+description: 'Follow a complete walkthrough to build a working web app with Softgen, from first prompt to deployed product.'
 ---
 
 ## Initial Setup

--- a/guides/stripe-payments.mdx
+++ b/guides/stripe-payments.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Stripe Payments'
-description: 'Implement secure payment processing with Stripe in your Full Stack project'
+title: 'Add Stripe Payments to Your App'
+description: 'Add secure Stripe payments to your full-stack Softgen app. Set up checkout, subscriptions, and webhooks with AI.'
 ---
 
 # Stripe Payments Integration Guide

--- a/guides/team-collaboration.mdx
+++ b/guides/team-collaboration.mdx
@@ -1,3 +1,8 @@
+---
+title: 'Team Collaboration'
+description: 'Invite teammates to build together in Softgen. Manage members, roles, and shared projects in one workspace.'
+---
+
 Team collaboration in Softgen.ai allows you to invite other members to work on your projects. This guide explains how to manage team members and understand the collaboration model.
 
 ## Inviting Team Members

--- a/integrations/github-integration.mdx
+++ b/integrations/github-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'GitHub Integration'
-description: 'Quickly connect your Softgen projects with GitHub'
+description: 'Connect your Softgen projects to GitHub. Sync code, push changes, and manage your repository alongside AI builds.'
 ---
 
 ## Overview

--- a/integrations/import-from-github.mdx
+++ b/integrations/import-from-github.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Import from GitHub'
-description: 'Bring an existing GitHub repository into Softgen and keep building with AI'
+description: 'Bring an existing GitHub repository into Softgen and keep building with AI. Connect, import, and ship faster.'
 ---
 
 ## Overview

--- a/introduction/capabilities.mdx
+++ b/introduction/capabilities.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Product Capabilities'
-description: 'Learn what Softgen can do for you'
+title: 'Softgen Capabilities: What You Can Build with AI'
+description: 'See what you can build with Softgen, from full-stack web apps and databases to auth, payments, and integrations, all with AI.'
 ---
 
 Softgen empowers you to build full-stack applications, featuring a 1-click Supabase integration for backend services. While Firebase was a previous default and is still usable, it requires manual setup outside the Softgen UI. This enables rapid development of production-ready applications with essential features.

--- a/introduction/quick-start.mdx
+++ b/introduction/quick-start.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Quick Start'
-description: 'Get started with Softgen in minutes'
+title: 'Quick Start: Build Your First App with AI'
+description: 'Build and launch your first web app with Softgen in minutes. A fast, step-by-step quick start for new builders.'
 ---
 
 ## Getting Started

--- a/introduction/stay-connected.mdx
+++ b/introduction/stay-connected.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Stay Connected'
-description: 'Join our community and stay updated'
+title: 'Stay Connected with the Softgen Community'
+description: 'Join the Softgen community for product updates, build tips, and support. Connect on Discord, X, and more.'
 ---
 
 Stay informed about the latest Softgen developments and get help when you need it through our official channels:

--- a/introduction/welcome.mdx
+++ b/introduction/welcome.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Welcome to Softgen Academy'
-description: 'Build real web apps fast using natural language with Softgen'
+title: 'Softgen Academy: Build Web Apps with AI'
+description: 'Learn to build and ship real, full-stack web apps with AI using natural language. Start here with the Softgen Academy.'
 ---
 
 Softgen is a revolutionary AI-powered platform that transforms natural language into fully functional web applications. Our platform empowers developers and non-developers alike to build sophisticated web applications quickly and efficiently.

--- a/plans/features-comparison.mdx
+++ b/plans/features-comparison.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Included with Membership'
-description: 'What you get with Softgen annual membership'
+description: 'See everything included with Softgen membership: AI models, full-stack tools, integrations, and support.'
 ---
 
 | Feature                      | Included |

--- a/plans/membership.mdx
+++ b/plans/membership.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Membership'
-description: 'Annual membership benefits and how to join'
+title: 'Softgen Membership'
+description: 'Learn about Softgen annual membership benefits, what is included, and how to join and start building.'
 ---
 
 Softgen's annual membership is $33/year and gives you full access to the platform. Pair it with wallet top-ups to pay only for what you use.

--- a/plans/pricing-plans.mdx
+++ b/plans/pricing-plans.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Pricing Plans'
-description: 'Annual membership with pay-as-you-go usage'
+title: 'Softgen Pricing Plans'
+description: 'See Softgen pricing: a $3 paid trial, then an annual membership with pay-as-you-go usage and no monthly fees.'
 ---
 
 ## Annual Membership ($33/year)

--- a/plans/understanding-tokens.mdx
+++ b/plans/understanding-tokens.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Understanding Tokens'
-description: 'Learn how Softgen usage is measured and billed'
+title: 'Understanding Tokens and Usage'
+description: 'Learn how Softgen measures and bills usage with tokens, and how to build efficiently to get the most from your credits.'
 ---
 
 Think of tokens as the “units” of work for AI models. Larger prompts, more open files, and longer conversations use more tokens.

--- a/plans/wallet-and-billing.mdx
+++ b/plans/wallet-and-billing.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Wallet & Billing'
-description: 'How pay-as-you-go usage and top-ups work'
+title: 'Wallet and Billing'
+description: 'Understand how pay-as-you-go usage, your wallet, and top-ups work in Softgen. Manage your billing with confidence.'
 ---
 
 Softgen uses a simple, pay-as-you-go wallet. Add funds, then usage deducts automatically as you build.

--- a/resources/faq.mdx
+++ b/resources/faq.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Frequently Asked Questions'
-description: 'Common questions about Softgen'
+title: 'Softgen FAQ: Common Questions Answered'
+description: 'Answers to common questions about Softgen: building with AI, pricing, full-stack features, and getting support.'
 ---
 
 <Accordion title="What is Softgen and how does it work?">

--- a/resources/how-it-works.mdx
+++ b/resources/how-it-works.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'How It Works'
-description: 'Learn how Softgen transforms your ideas into code'
+title: 'How Softgen Works'
+description: 'See how Softgen turns plain language into real, working web apps. Understand the AI build process from prompt to product.'
 ---
 
 ## The Process

--- a/resources/referrals-and-credits.mdx
+++ b/resources/referrals-and-credits.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Referrals & Credits'
-description: 'Share Softgen and earn usage credits'
+title: 'Referrals and Credits'
+description: 'Share Softgen with others and earn usage credits. Learn how the referral program works and how to start.'
 ---
 
 Invite friends to Softgen and earn credits toward your usage.


### PR DESCRIPTION
## Summary

SEO pass on the Academy docs from the Search Console audit. The pages had strong impressions but weak CTR from generic or missing meta.

### Changes
- Rewrote titles and meta descriptions for all 33 live nav pages, keyword-focused for ranking and CTR.
- Fixed `developer-tools/network-debugging` and `developer-tools/console-debugging`, which were missing their `---` frontmatter delimiters, so the meta was rendering as body text instead of metadata.
- Added frontmatter to `guides/team-collaboration`, which had none.